### PR TITLE
fix: Handle undefined for user creation time in formatDate

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -145,7 +145,7 @@ export default function SettingsPage() {
     )
   }
 
-  const formatDate = (timestamp: string | null) => {
+  const formatDate = (timestamp: string | null | undefined) => {
     if (!timestamp) return "No disponible"
     return new Date(timestamp).toLocaleDateString("es-ES", {
       year: "numeric",


### PR DESCRIPTION
## Overview
This PR fixes a TypeScript error by updating the formatDate function to correctly accept string | null | undefined as input. This ensures user.metadata.creationTime is handled, displaying "No disponible" when the timestamp is not valid.