### PR TITLE
fix: Exclude Deleted Events from Listings

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -63,19 +63,29 @@ export default function AdminPage() {
       let recentUsers: any[] = []
 
       try {
-        // Obtener estadísticas de eventos
+        // Obtener estadísticas de eventos (solo activos)
         console.log("Fetching events...")
         const eventsQuery = query(collection(db, "events"))
         const eventsSnapshot = await getDocs(eventsQuery)
-        totalEvents = eventsSnapshot.size
+        // Filtrar eventos no eliminados (status !== "deleted")
+        const activeEvents = eventsSnapshot.docs.filter((doc) => doc.data().status !== "deleted")
+        totalEvents = activeEvents.length
 
-        // Obtener eventos recientes
-        const recentEventsQuery = query(collection(db, "events"), orderBy("createdAt", "desc"), limit(5))
+        // Obtener eventos recientes (solo activos)
+        const recentEventsQuery = query(
+          collection(db, "events"),
+          orderBy("createdAt", "desc"),
+          limit(10), // Obtenemos más para filtrar después
+        )
         const recentEventsSnapshot = await getDocs(recentEventsQuery)
-        recentEvents = recentEventsSnapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...doc.data(),
-        }))
+        // Filtrar eventos no eliminados y tomar solo 5
+        recentEvents = recentEventsSnapshot.docs
+          .filter((doc) => doc.data().status !== "deleted")
+          .slice(0, 5)
+          .map((doc) => ({
+            id: doc.id,
+            ...doc.data(),
+          }))
         console.log("Events loaded:", totalEvents)
       } catch (eventsError) {
         console.warn("Error loading events:", eventsError)


### PR DESCRIPTION
## Overview
This PR corrects the event filtering logic to ensure that events marked with status: "deleted" are no longer displayed in the listings.

## Motivation
The primary motivation for this fix is to:
- Improve Data Accuracy: Ensure that only active and relevant event data is presented to users.
- Maintain Data Integrity: Prevent logically deleted events from appearing where they shouldn't, aligning the frontend display with the intended data state.

## Changes Implemented
- Status Filter Correction: Implemented the filter condition doc.data().status !== "deleted" to explicitly exclude deleted events.
- Consistent Filtering: Applied this filter criterion to both main event listings and recent events sections, ensuring consistent behavior across the board.

This change ensures that the application now correctly displays only non-deleted events.